### PR TITLE
修改easytier使用源码编译

### DIFF
--- a/easytier/Makefile
+++ b/easytier/Makefile
@@ -2,64 +2,106 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=easytier
 PKG_VERSION:=2.3.2
+PKG_RELEASE:=2
 
-ifeq ($(ARCH),mipsel)
-	APP_ARCH:=mipsel
-endif
-ifeq ($(ARCH),mips)
-	APP_ARCH:=mips
-endif
-ifeq ($(ARCH),arm)
-	APP_ARCH:=arm
-endif
-ifeq ($(BOARD),kirkwood)
-	APP_ARCH:=arm
-endif
-ifeq ($(ARCH),armv7)
-	APP_ARCH:=armv7
-endif
-ifeq ($(ARCH),aarch64)
-	APP_ARCH:=aarch64
-endif
-ifeq ($(ARCH),arm64)
-	APP_ARCH:=aarch64
-endif
-ifeq ($(ARCH),armv8)
-	APP_ARCH:=aarch64
-endif
-ifeq ($(ARCH),x86_64)
-	APP_ARCH:=x86_64
-endif
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/EasyTier/EasyTier/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=bd1b3345346468555e473d0244b7672caf41c7b7d581469729f0e2b4bae826b8
+PKG_SOURCE_SUBDIR:=EasyTier-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_SUBDIR)
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
+PKG_MAINTAINER:=lazyoop <lazyoop@nas.lan>
+PKG_LICENSE:=LGPL-3.0
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DEPENDS:=node/host rust/host protobuf/host upx/host
+PKG_BUILD_PARALLEL:=1
+
+CARGO_PKG_VARS += PROTOC=$(STAGING_DIR_HOSTPKG)/bin/protoc
+PNPM_STORE_PATH := $(PKG_BUILD_DIR)/.pnpm-store
 
 include $(INCLUDE_DIR)/package.mk
+include ../../lang/rust/rust-package.mk
+
+ifeq ($(ARCH),mipsel)
+  RUST_TARGET:=mipsel-unknown-linux-musl
+else ifeq ($(ARCH),mips)
+  RUST_TARGET:=mips-unknown-linux-musl
+else ifeq ($(BOARD),kirkwood)
+  RUST_TARGET:=arm-unknown-linux-musleabi
+else ifeq ($(ARCH),arm)
+  ifeq ($(CONFIG_TARGET_ARM_V7),y)
+  	ifeq ($(CONFIG_ARCH_ARM_HARD_FLOAT),y)
+  	  RUST_TARGET:=armv7-unknown-linux-musleabihf
+  	else
+      RUST_TARGET:=armv7-unknown-linux-musleabi
+  	endif
+  else
+  	ifeq ($(CONFIG_ARCH_ARM_HARD_FLOAT),y)
+  	  RUST_TARGET:=arm-unknown-linux-musleabihf
+  	else
+      RUST_TARGET:=arm-unknown-linux-musleabi
+  	endif
+  endif
+else ifeq ($(ARCH),aarch64)
+  RUST_TARGET:=aarch64-unknown-linux-musl
+else ifeq ($(ARCH),x86_64)
+  RUST_TARGET:=x86_64-unknown-linux-musl
+else ifeq ($(ARCH),i386)
+  RUST_TARGET:=i686-unknown-linux-musl
+else
+  RUST_TARGET:=dummy
+endif
 
 define Package/$(PKG_NAME)
 	SECTION:=net
 	CATEGORY:=Network
+	SUBMENU:=VPN
 	TITLE:=A simple, decentralized mesh VPN with WireGuard support.
-	DEPENDS:=@(x86_64||arm||aarch64||mipsel||mips) +kmod-tun
+	DEPENDS:=@(x86_64||arm||aarch64||mipsel||mips||i386) +kmod-tun
 	URL:=https://github.com/EasyTier/EasyTier
 endef
 
 define Package/$(PKG_NAME)/description
-  A simple, decentralized mesh VPN with WireGuard support.
+	A simple, decentralized mesh VPN with WireGuard support.
+endef
+
+define Package/$(PKG_NAME)/config
+  config EASYTIER_COMPRESS_UPX
+    bool "Compress $(PKG_NAME) with UPX"
+    default y
 endef
 
 define Build/Prepare
-	[ ! -f $(PKG_BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION).zip ] && wget https://github.com/EasyTier/EasyTier/releases/download/v$(PKG_VERSION)/$(PKG_NAME)-linux-$(APP_ARCH)-v$(PKG_VERSION).zip -O $(PKG_NAME)-$(PKG_VERSION).zip
-	unzip -j $(PKG_NAME)-$(PKG_VERSION).zip -d $(PKG_BUILD_DIR)
+	$(call Build/Prepare/Default)
+ifeq ($(filter mips mipsel,$(ARCH)),)
+	cd $(PKG_BUILD_DIR) && $(STAGING_DIR_HOSTPKG)/bin/npm install --no-save pnpm
+	echo "store-dir=$(PNPM_STORE_PATH)" > $(PKG_BUILD_DIR)/.npmrc
+	echo "frozen-lockfile=true" >> $(PKG_BUILD_DIR)/.npmrc
+endif
 endef
 
 define Build/Compile
+	$(call Build/Compile/Cargo,easytier,--locked)
+
+ifeq ($(filter mips mipsel,$(ARCH)),)
+	cd $(PKG_BUILD_DIR) && $(STAGING_DIR_HOSTPKG)/bin/npx pnpm --frozen-lockfile -r install
+	cd $(PKG_BUILD_DIR) && $(STAGING_DIR_HOSTPKG)/bin/npx pnpm --frozen-lockfile -r --filter "./easytier-web/*" build
+	$(call Build/Compile/Cargo,easytier-web,--locked --features embed)
+endif
+ifeq ($(CONFIG_EASYTIER_COMPRESS_UPX),y)
+	$(STAGING_DIR_HOST)/bin/upx --lzma --best $(PKG_INSTALL_DIR)/bin/easytier-*
+endif
 endef
 
 define Package/$(PKG_NAME)/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/easytier-core $(1)/usr/bin/easytier-core
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/easytier-cli $(1)/usr/bin/easytier-cli
-	[ "$(APP_ARCH)" != "mips" ] && [ "$(APP_ARCH)" != "mipsel" ] && $(INSTALL_BIN) $(PKG_BUILD_DIR)/easytier-web-embed $(1)/usr/bin/easytier-web || true
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/bin/easytier-core $(1)/usr/bin/easytier-core
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/bin/easytier-cli $(1)/usr/bin/easytier-cli
+	@if [ "$(ARCH)" != "mips" ] && [ "$(ARCH)" != "mipsel" ]; then \
+		$(INSTALL_BIN) $(PKG_INSTALL_DIR)/bin/easytier-web $(1)/usr/bin/easytier-web; \
+	fi
 endef
 
+$(eval $(call RustBinPackage,$(PKG_NAME)))
 $(eval $(call BuildPackage,$(PKG_NAME)))

--- a/ucl/Makefile
+++ b/ucl/Makefile
@@ -1,0 +1,69 @@
+#
+# Copyright (C) 2019-2020 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ucl
+PKG_VERSION:=1.03
+PKG_RELEASE:=3
+
+PKG_MAINTAINER:=Xingwang Liao <kuoruan@gmail.com>
+PKG_LICENSE:=GPL-2.0-only
+PKG_LICENSE_FILES:=COPYING
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://www.oberhumer.com/opensource/ucl/download
+PKG_HASH:=b865299ffd45d73412293369c9754b07637680e5c826915f097577cd27350348
+
+PKG_FIXUP:=autoreconf
+PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
+
+HOST_FIXUP:=autoreconf
+HOST_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/host-build.mk
+include $(INCLUDE_DIR)/package.mk
+
+HOST_BUILD_PREFIX:=$(STAGING_DIR_HOST)
+
+HOST_CFLAGS += -std=gnu89
+TARGET_CFLAGS += -std=gnu89
+
+CONFIGURE_ARGS += \
+	--enable-static \
+	--enable-shared \
+	--disable-asm
+
+define Package/libucl
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Portable lossless data compression library
+  URL:=http://www.oberhumer.com/opensource/ucl/
+endef
+
+define Package/libucl/description
+UCL is a portable lossless data compression library written in ANSI C. UCL
+implements a number of compression algorithms that achieve an excellent
+compression ratio while allowing *very* fast decompression. Decompression
+requires no additional memory.
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/ucl
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/ucl/ucl{,conf}.h $(1)/usr/include/ucl/
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libucl.{a,so*} $(1)/usr/lib/
+endef
+
+define Package/libucl/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libucl.so.* $(1)/usr/lib/
+endef
+
+$(eval $(call HostBuild))
+$(eval $(call BuildPackage,libucl))

--- a/ucl/patches/001-autoconf-compat.patch
+++ b/ucl/patches/001-autoconf-compat.patch
@@ -1,0 +1,11 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -48,7 +48,7 @@ AC_CANONICAL_TARGET
+ AM_MAINTAINER_MODE
+
+ if test -z "$ac_abs_top_srcdir"; then
+-    _AC_SRCPATHS(.)
++    _AC_SRCDIRS(.)
+ fi
+ if test -r .Conf.settings1; then
+     . ./.Conf.settings1

--- a/upx/Makefile
+++ b/upx/Makefile
@@ -1,21 +1,17 @@
-#
-# Copyright (C) 2011-2020 OpenWrt.org
-#
-# This is free software, licensed under the GNU General Public License v2.
-# See /LICENSE for more information.
-#
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=upx
-PKG_VERSION:=4.2.4
+PKG_VERSION:=5.0.1
 PKG_RELEASE:=1
 
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/upx/upx.git
-PKG_SOURCE_VERSION:=3757579ffc6fa8710b4b7a1055529fea9dcaf149
-PKG_MIRROR_HASH:=3d529c371a863de2aa0bc2d23c5039fa3d2edb7462c66429312e2510ebeb8dec
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-src.tar.xz
+PKG_SOURCE_URL:=https://github.com/upx/upx/releases/download/$(PKG_VERSION)/$(PKG_SOURCE)
+PKG_HASH:=2b11323a9f6c7f0247a4936deee35afb486a2fdf808a5bc4abf10a085ec884d9
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)-src
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_SUBDIR)
+HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/$(PKG_SOURCE_SUBDIR)
 
-PKG_MAINTAINER:=Xingwang Liao <kuoruan@gmail.com>
+PKG_MAINTAINER:=dev <dev@nas.lan>
 PKG_LICENSE:=GPL-2.0-only
 PKG_LICENSE_FILES:=COPYING LICENSE
 

--- a/upx/Makefile
+++ b/upx/Makefile
@@ -1,0 +1,62 @@
+#
+# Copyright (C) 2011-2020 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=upx
+PKG_VERSION:=4.2.4
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/upx/upx.git
+PKG_SOURCE_VERSION:=3757579ffc6fa8710b4b7a1055529fea9dcaf149
+PKG_MIRROR_HASH:=3d529c371a863de2aa0bc2d23c5039fa3d2edb7462c66429312e2510ebeb8dec
+
+PKG_MAINTAINER:=Xingwang Liao <kuoruan@gmail.com>
+PKG_LICENSE:=GPL-2.0-only
+PKG_LICENSE_FILES:=COPYING LICENSE
+
+HOST_BUILD_DEPENDS:=ucl/host
+MAKE_PATH:=src
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
+
+define Package/upx
+  SECTION:=utils
+  CATEGORY:=Utilities
+  DEPENDS:=+libucl +libstdcpp +zlib
+  TITLE:=The Ultimate Packer for eXecutables
+  URL:=https://upx.github.io/
+endef
+
+define Package/upx/description
+UPX is a free, secure, portable, extendable, high-performance
+executable packer for several executable formats.
+endef
+
+define Host/Compile
+	UPX_UCLDIR=$(STAGING_DIR_HOST) \
+	$(MAKE) -C $(HOST_BUILD_DIR)/src \
+		LDFLAGS="$(HOST_LDFLAGS)" \
+		CXX="$(HOSTCXX)"
+endef
+
+define Host/Install
+	$(CP) $(HOST_BUILD_DIR)/build/release/upx $(STAGING_DIR_HOST)/bin/upx
+endef
+
+define Host/Clean
+	rm -f $(STAGING_DIR_HOST)/bin/upx
+endef
+
+define Package/upx/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/build/release/upx $(1)/usr/bin/upx
+endef
+
+$(eval $(call HostBuild))
+$(eval $(call BuildPackage,upx))


### PR DESCRIPTION
注意事项：
1. 由于easytier是rust编写，openwrt在23.05支持了rust，故低于openwrt 23.05将无法编译。低于openwrt 23.05可添加rust解决。
2. 已在openwrt-21.02进行编译测试通过，使用的环境：目标架构aarch64，rust为1.85.0版本，nodejs为20.19.0版本，protobuf为3.17.3版本。