### PR TITLE
检测可以用空间时 df -k 加上-P参数让输出不换行

### DIFF
--- a/luci-app-easytier/root/etc/init.d/easytier
+++ b/luci-app-easytier/root/etc/init.d/easytier
@@ -702,7 +702,7 @@ start_service() {
         echo "" >/tmp/easytier.log
 	echo "" >/tmp/easytierweb.log
         size="$(df -k | awk '/\/overlay$/ {sub(/K$/, "", $4); print $4}')"
-	[ -z "$size" ] && size="$(df -k /usr/bin | awk 'NR==2 {print $(NF-2) }')"
+	[ -z "$size" ] && size="$(df -kP /usr/bin | awk 'NR==2 {print $(NF-2) }')"
 	if [ -z "$(uci -q get easytier.@easytierweb[0].enabled)" ] ; then
 		echo "config easytierweb" >>/etc/config/easytier
 		echo "	option enabled '0'" >>/etc/config/easytier


### PR DESCRIPTION
在pve里通过lxc容器安装的openwrt 运行 df -k时输出会换行
```
root@openwrt24:~# df -k
Filesystem           1K-blocks      Used Available Use% Mounted on
/dev/mapper/pve-vm--301--disk--0
                       4046560    265632   3554832   7% /
none                       492         8       484   2% /dev
udev                   8040208         0   8040208   0% /dev/fuse
udev                   8040208         0   8040208   0% /dev/ppp
udev                   8040208         0   8040208   0% /dev/net/tun
none                       492         8       484   2% /proc/sys/kernel/random/boot_id
tmpfs                  8077564      1888   8075676   0% /tmp
```

会导致脚本报错无法启动easytier服务:
```
root@openwrt24:~# df -k /usr/bin | awk 'NR==2 {print $(NF-2) }'
awk: cmd. line:1: Access to negative field
```

加上-P参数可以使输出不换行，正常执行：
```
root@openwrt24:~# df -kP /usr/bin | awk 'NR==2 {print $(NF-2) }'
3554832
```

```
root@openwrt24:~# df -kP
Filesystem           1024-blocks    Used Available Capacity Mounted on
/dev/mapper/pve-vm--301--disk--0   4046560    265632   3554832   7% /
none                       492         8       484   2% /dev
udev                   8040208         0   8040208   0% /dev/fuse
udev                   8040208         0   8040208   0% /dev/ppp
udev                   8040208         0   8040208   0% /dev/net/tun
none                       492         8       484   2% /proc/sys/kernel/random/boot_id
tmpfs                  8077564      1888   8075676   0% /tmp
```



