### PR TITLE
feat: add option to include easytier-web for easytier package

### DIFF
--- a/easytier/Makefile
+++ b/easytier/Makefile
@@ -41,10 +41,21 @@ define Package/$(PKG_NAME)
 	TITLE:=A simple, decentralized mesh VPN with WireGuard support.
 	DEPENDS:=@(x86_64||arm||aarch64||mipsel||mips) +kmod-tun
 	URL:=https://github.com/EasyTier/EasyTier
+	MENU:=1
 endef
 
 define Package/$(PKG_NAME)/description
   A simple, decentralized mesh VPN with WireGuard support.
+endef
+
+define Package/$(PKG_NAME)/config
+	config EASYTIER_INCLUDE_WEBCONSOLE
+		bool "Include Web Console (easytier-web)"
+		depends on PACKAGE_$(PKG_NAME)
+		depends on !@(mips||mipsel)
+		default y
+		help
+		  Install the easytier-web web console.
 endef
 
 define Build/Prepare
@@ -59,7 +70,9 @@ define Package/$(PKG_NAME)/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/easytier-core $(1)/usr/bin/easytier-core
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/easytier-cli $(1)/usr/bin/easytier-cli
-	[ "$(APP_ARCH)" != "mips" ] && [ "$(APP_ARCH)" != "mipsel" ] && $(INSTALL_BIN) $(PKG_BUILD_DIR)/easytier-web-embed $(1)/usr/bin/easytier-web || true
+ifdef CONFIG_EASYTIER_INCLUDE_WEBCONSOLE
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/easytier-web-embed $(1)/usr/bin/easytier-web
+endif
 endef
 
 $(eval $(call BuildPackage,$(PKG_NAME)))


### PR DESCRIPTION
添加了通过 menuconfig 配置的可选安装 Web 控制台（easytier-web）的选项，以减少在小容量路由设备上的占用空间

该选项：
 - 仅在勾选了 easytier  包时生效
 - 仅在非 mips, mipsel 架构上生效（在这两个架构时则不会安装）
 - 默认为安装，与之前版本行为一致

Fix #91 