### PR TITLE
拆分easytier包：easytier(含web)和easytier-noweb(不含web)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
         env:
           ARCH: ${{ matrix.arch }}-${{ matrix.sdk }}
           FEEDNAME: packages_ci
-          PACKAGES: easytier luci-app-easytier
+          PACKAGES: easytier easytier-noweb luci-app-easytier
           #NO_DEFAULT_FEEDS: 1
           NO_REFRESH_CHECK: 1
           NO_SHFMT_CHECK: 1
@@ -119,7 +119,7 @@ jobs:
           mkdir -p release
           for dir in artifacts/*; do
             name=$(basename "$dir")
-            zip -j "release/EasyTier-${{ env.TAG }}-${name}.zip" "$dir"/*
+            zip -j "release/EasyTier-${{ env.TAG }}-${name}.zip" "$dir"/*.ipk "$dir"/*.apk 2>/dev/null || true
           done
           echo "build_time=$(TZ=UTC-8 date '+%Y年%m月%d日%H:%M:%S' | jq -sRr @uri)" >> $GITHUB_ENV
 

--- a/easytier-noweb/Makefile
+++ b/easytier-noweb/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 -include $(dir $(lastword $(MAKEFILE_LIST)))../version.mk
 
-PKG_NAME:=easytier
+PKG_NAME:=easytier-noweb
 PKG_VERSION:=$(or $(EASYTIER_VERSION),2.6.2)
 
 ifeq ($(ARCH),mipsel)
@@ -39,14 +39,14 @@ include $(INCLUDE_DIR)/package.mk
 define Package/$(PKG_NAME)
 	SECTION:=net
 	CATEGORY:=Network
-	DEPENDS:=@(x86_64||arm||aarch64) +kmod-tun
-	TITLE:=A simple, decentralized mesh VPN with WireGuard support (with Web Console).
+	TITLE:=A simple, decentralized mesh VPN with WireGuard support.
+	DEPENDS:=@(x86_64||arm||aarch64||mipsel||mips) +kmod-tun
 	URL:=https://github.com/EasyTier/EasyTier
 	MENU:=1
 endef
 
 define Package/$(PKG_NAME)/description
-  EasyTier with Web Console. Includes easytier-core, easytier-cli and easytier-web.
+  A simple, decentralized mesh VPN with WireGuard support.
 endef
 
 define Build/Prepare
@@ -65,7 +65,6 @@ define Package/$(PKG_NAME)/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/easytier-core $(1)/usr/bin/easytier-core
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/easytier-cli $(1)/usr/bin/easytier-cli
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/easytier-web-embed $(1)/usr/bin/easytier-web
 endef
 
 $(eval $(call BuildPackage,$(PKG_NAME)))

--- a/easytier/Makefile
+++ b/easytier/Makefile
@@ -39,22 +39,32 @@ include $(INCLUDE_DIR)/package.mk
 define Package/$(PKG_NAME)
 	SECTION:=net
 	CATEGORY:=Network
-	DEPENDS:=@(x86_64||arm||aarch64) +kmod-tun
-	TITLE:=A simple, decentralized mesh VPN with WireGuard support (with Web Console).
+	TITLE:=A simple, decentralized mesh VPN with WireGuard support.
+	DEPENDS:=@(x86_64||arm||aarch64||mipsel||mips) +kmod-tun
 	URL:=https://github.com/EasyTier/EasyTier
 	MENU:=1
 endef
 
 define Package/$(PKG_NAME)/description
-  EasyTier with Web Console. Includes easytier-core, easytier-cli and easytier-web.
+  A simple, decentralized mesh VPN with WireGuard support.
+endef
+
+define Package/$(PKG_NAME)/config
+	config EASYTIER_INCLUDE_WEBCONSOLE
+		bool "Include Web Console (easytier-web)"
+		depends on PACKAGE_$(PKG_NAME)
+		depends on !(mips || mipsel)
+		default y
+		help
+		  Install the easytier-web web console.
 endef
 
 define Build/Prepare
 	mkdir -p $(PKG_BUILD_DIR)
 	if [ ! -f $(PKG_BUILD_DIR)/easytier-core ]; then \
-		wget https://github.com/EasyTier/EasyTier/releases/download/v$(PKG_VERSION)/easytier-linux-$(APP_ARCH)-v$(PKG_VERSION).zip -O $(PKG_BUILD_DIR)/easytier-$(PKG_VERSION).zip; \
-		unzip -o -j $(PKG_BUILD_DIR)/easytier-$(PKG_VERSION).zip -d $(PKG_BUILD_DIR); \
-		rm -f $(PKG_BUILD_DIR)/easytier-$(PKG_VERSION).zip; \
+		wget https://github.com/EasyTier/EasyTier/releases/download/v$(PKG_VERSION)/$(PKG_NAME)-linux-$(APP_ARCH)-v$(PKG_VERSION).zip -O $(PKG_BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION).zip; \
+		unzip -o -j $(PKG_BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION).zip -d $(PKG_BUILD_DIR); \
+		rm -f $(PKG_BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION).zip; \
 	fi
 endef
 
@@ -65,7 +75,9 @@ define Package/$(PKG_NAME)/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/easytier-core $(1)/usr/bin/easytier-core
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/easytier-cli $(1)/usr/bin/easytier-cli
+ifdef CONFIG_EASYTIER_INCLUDE_WEBCONSOLE
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/easytier-web-embed $(1)/usr/bin/easytier-web
+endif
 endef
 
 $(eval $(call BuildPackage,$(PKG_NAME)))


### PR DESCRIPTION
- 新增 easytier/ 包含 web 控制台 (easytier-core + easytier-cli + easytier-web)
- 新增 easytier-noweb/ 仅包含核心组件 (easytier-core + easytier-cli)
- 更新 CI workflow 同时编译两个包，release zip 包含所有包

#143 