### PR TITLE
easytier-noweb: verify release downloads

### DIFF
--- a/easytier-noweb/Makefile
+++ b/easytier-noweb/Makefile
@@ -6,35 +6,54 @@ PKG_VERSION:=$(or $(EASYTIER_VERSION),2.6.4)
 
 ifeq ($(ARCH),mipsel)
 	APP_ARCH:=mipsel
+	APP_HASH:=7c93bcc9e9276f102b5299b0773941db7fd1d99ad04bac42b479a0d979ef5220
 endif
 ifeq ($(ARCH),mips)
 	APP_ARCH:=mips
+	APP_HASH:=3b4d084aa922a4b23f5d0167b9bb4966c1593f5184061f7ff075132a2207a260
 endif
 ifeq ($(ARCH),arm)
 	APP_ARCH:=arm
+	APP_HASH:=6d2bd44507d7183a4fa9857ced8f89cb4eddc99cdfc8f8ddef5cc78f52caf2fd
 endif
 ifeq ($(BOARD),kirkwood)
 	APP_ARCH:=arm
+	APP_HASH:=6d2bd44507d7183a4fa9857ced8f89cb4eddc99cdfc8f8ddef5cc78f52caf2fd
 endif
 ifeq ($(ARCH),armv7)
 	APP_ARCH:=armv7
+	APP_HASH:=93b1d2831e45db1fd3ca1d8d68c191b300bd69d331ca1858394a0cf884363cc3
 endif
 ifeq ($(ARCH),aarch64)
 	APP_ARCH:=aarch64
+	APP_HASH:=f533ec25a7ea714e09f645615012200278058525795cc3bb690ff011aec1a70f
 endif
 ifeq ($(ARCH),arm64)
 	APP_ARCH:=aarch64
+	APP_HASH:=f533ec25a7ea714e09f645615012200278058525795cc3bb690ff011aec1a70f
 endif
 ifeq ($(ARCH),armv8)
 	APP_ARCH:=aarch64
+	APP_HASH:=f533ec25a7ea714e09f645615012200278058525795cc3bb690ff011aec1a70f
 endif
 ifeq ($(ARCH),x86_64)
 	APP_ARCH:=x86_64
+	APP_HASH:=61b659eaedba658fa66fe47d17e1426cdd77e5d02fa15fed447bb4357c09dfd6
 endif
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
+
+EASYTIER_ARCHIVE:=easytier-linux-$(APP_ARCH)-v$(PKG_VERSION).zip
+
+define Download/easytier
+  FILE:=$(EASYTIER_ARCHIVE)
+  URL:=https://github.com/EasyTier/EasyTier/releases/download/v$(PKG_VERSION)
+  HASH:=$(APP_HASH)
+endef
+
+$(eval $(call Download,easytier))
 
 RSTRIP:=:
 
@@ -53,11 +72,7 @@ endef
 
 define Build/Prepare
 	mkdir -p $(PKG_BUILD_DIR)
-	if [ ! -f $(PKG_BUILD_DIR)/easytier-core ]; then \
-		wget https://github.com/EasyTier/EasyTier/releases/download/v$(PKG_VERSION)/easytier-linux-$(APP_ARCH)-v$(PKG_VERSION).zip -O $(PKG_BUILD_DIR)/easytier-$(PKG_VERSION).zip; \
-		unzip -o -j $(PKG_BUILD_DIR)/easytier-$(PKG_VERSION).zip -d $(PKG_BUILD_DIR); \
-		rm -f $(PKG_BUILD_DIR)/easytier-$(PKG_VERSION).zip; \
-	fi
+	unzip -o -j $(DL_DIR)/$(EASYTIER_ARCHIVE) -d $(PKG_BUILD_DIR)
 endef
 
 define Build/Compile


### PR DESCRIPTION
## Summary

- fetch the architecture-specific EasyTier release archive through OpenWrt's `Download` infrastructure
- verify every supported v2.6.4 archive with its published SHA-256 digest
- unpack the verified archive from `$(DL_DIR)` during preparation

## Why

`easytier-noweb` currently runs `wget` directly during `Build/Prepare`. That bypasses OpenWrt's download cache and accepts release binaries without integrity verification. It also makes offline or mirrored rebuilds harder.

Using a named `Download` definition gives the package the normal OpenWrt caching, mirror, retry, and hash-verification behavior.

## Impact

Runtime package contents and supported architectures are unchanged. Builds now fail safely if a release archive does not match its expected digest. When `EASYTIER_VERSION` is updated, the corresponding architecture hashes must be updated as part of the version bump.

## Validation

- matched all six configured SHA-256 values against the digests published for the EasyTier v2.6.4 GitHub release assets
- parsed the Makefile against an OpenWrt build tree for `ARCH=aarch64`; the generated download rule resolves the expected URL, archive name, and SHA-256
- `git diff --check upstream/main...HEAD`

