### PR TITLE
fix: rotate EasyTier logs in place

### DIFF
--- a/luci-app-easytier/root/etc/init.d/easytier
+++ b/luci-app-easytier/root/etc/init.d/easytier
@@ -181,9 +181,11 @@ check_config() {
 				LOG_SIZE=\$(ls -l /tmp/easytier.log | awk '{print int(\$5/1024)}')
 				if [ \$LOG_SIZE -gt 5120 ]; then
 					tail -n 500 /tmp/easytier.log > /tmp/easytier.log.tmp
-					mv /tmp/easytier.log.tmp /tmp/easytier.log
+					: > /tmp/easytier.log
+					cat /tmp/easytier.log.tmp >> /tmp/easytier.log
+					rm -f /tmp/easytier.log.tmp
 				fi
-				sleep 300
+				sleep 60
 			done
 			} &
 			LOG_MANAGEMENT_PID=\$!
@@ -604,9 +606,11 @@ EOF
 				LOG_SIZE=\$(ls -l /tmp/easytier.log | awk '{print int(\$5/1024)}')
 				if [ \$LOG_SIZE -gt 5120 ]; then
 					tail -n 500 /tmp/easytier.log > /tmp/easytier.log.tmp
-					mv /tmp/easytier.log.tmp /tmp/easytier.log
+					: > /tmp/easytier.log
+					cat /tmp/easytier.log.tmp >> /tmp/easytier.log
+					rm -f /tmp/easytier.log.tmp
 				fi
-				sleep 300
+				sleep 60
 			done
 			} &
 			LOG_MANAGEMENT_PID=\$!
@@ -753,9 +757,11 @@ start_web() {
 				LOG_SIZE=\$(ls -l /tmp/easytierweb.log | awk '{print int(\$5/1024)}')
 				if [ \$LOG_SIZE -gt 5120 ]; then
 					tail -n 500 /tmp/easytierweb.log > /tmp/easytierweb.log.tmp
-					mv /tmp/easytierweb.log.tmp /tmp/easytierweb.log
+					: > /tmp/easytierweb.log
+					cat /tmp/easytierweb.log.tmp >> /tmp/easytierweb.log
+					rm -f /tmp/easytierweb.log.tmp
 				fi
-				sleep 300
+				sleep 60
 			done
 		} &
 		LOG_MANAGEMENT_PID=\$!


### PR DESCRIPTION
## Summary

- truncate the active log inode before restoring the last 500 lines
- remove temporary rotation files after copying
- check log size every 60 seconds to limit peak usage during error bursts

Replacing an active log with `mv` leaves EasyTier writing to the deleted inode. On tmpfs, that space remains allocated while `du /tmp` cannot see it, eventually filling `/tmp`.

## Validation

- `sh -n luci-app-easytier/root/etc/init.d/easytier`
- verified rotation with a process holding the log file descriptor open
- deployed and restarted on three OpenWrt nodes; the active file descriptors point to visible log paths and no deleted EasyTier log descriptors remain